### PR TITLE
Blacklist existing keys to avoid re-registering a key under the same user

### DIFF
--- a/django_u2f/templates/u2f/add_key.html
+++ b/django_u2f/templates/u2f/add_key.html
@@ -13,7 +13,8 @@
 
 <script>
     var challenge = {{ challenge|json }};
-    u2f.register([challenge], [], function(resp) {
+    var signRequests = {{ sign_requests|json }};
+    u2f.register([challenge], signRequests, function(resp) {
         var form = document.getElementById('u2f-form');
         form.response.value = JSON.stringify(resp);
         if ( ! handleU2FError(resp) ) {

--- a/django_u2f/views.py
+++ b/django_u2f/views.py
@@ -91,8 +91,16 @@ class AddKeyView(FormView):
         challenge = u2f.start_register(self.get_origin())
         self.request.session['u2f_registration_challenge'] = challenge
         kwargs['challenge'] = challenge
-        # TODO: also blacklist the keys already added to the account (the
-        # second argument of u2f.register)
+
+        # Create a SignRequest for each key that has already been added to the
+        # account.
+        # This can be passed to u2f.register as the second parameter to prevent
+        # re-registering the same key for the same user.
+        sign_requests = [
+            u2f.start_authenticate(d.to_json()) for d in self.request.user.u2f_keys.all()
+        ]
+        kwargs['sign_requests'] = sign_requests
+
         return kwargs
 
     def form_valid(self, form):


### PR DESCRIPTION
I saw a TODO that mentioned blacklisting existing keys, and implemented it. This involved creating a SignRequest for each key that a user had already registered, and passing them as a context variable so they could be given to the JavaScript client API (as the second parameter of `u2f.register`).

Now, in testproj, attempting to add a key already in use by the given user will result in an error code of 4, [corresponding to "DEVICE_INELIGIBLE"](http://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-u2f-javascript-api-ps-20141009.html#error-codes) (which is the expected behavior).

Note that this doesn't actually blacklist keys by itself; if someone uses django-u2f and doesn't use the `sign_requests` context variable as part of their call to `u2f.register`, the key will get registered again. It's up to them to use it properly (as in testproj).