### PR TITLE
Store login_counter and verify it's increasing

### DIFF
--- a/django_u2f/models.py
+++ b/django_u2f/models.py
@@ -6,6 +6,7 @@ class U2FKey(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='u2f_keys')
     created_at = models.DateTimeField(auto_now_add=True)
     last_used_at = models.DateTimeField(null=True)
+    last_counter_value = models.PositiveIntegerField(default=0)
 
     public_key = models.TextField()
     key_handle = models.TextField()


### PR DESCRIPTION
Implemented a TODO related to a token's counter. The counter is [stored by the token, starts at 0](http://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-u2f-implementation-considerations-ps-20141009.html#token-counters), and should always increase. If not, it [may be an indication that the original device has been cloned](http://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-u2f-overview-ps-20141009.html#counters-as-a-signal-for-detecting-cloned-u2f-devices). (However, as far as I can tell, the device _may_ also have wrapped around to 0 after reaching its maximum value.)

This patch adds a field to the U2FKey model for the last seen counter value. Upon successful authentication, it updates the counter value to the current value. However, if the counter value is not larger than the last seen value, it doesn't sign the user in (nor update the last seen value). A signal is provided to allow a website to perform their own actions (e.g., sending a warning email or locking the user's account pending some further action).

There are some things that should probably be decided before this is pulled. First of all, since this is a model change, it might be good to provide a migration. I didn't see any existing migrations, so perhaps it would be worth adding one? (It wouldn't help for this change, but would for any future changes.) If you think this is a good idea, I'm happy to create one and add it to the pull request.

Secondly, is refusing to authenticate the user the correct behavior? Or should it only send the signal, and allow the website to decide what to do? (I like the idea of being flexible, but I also like the idea of good defaults...not sure what the right balance is here.)

Finally, I'd like to add a test to verify that the signal gets sent, but I'm not sure of the best way to test signals. It looks like we might need to add a mock library such as [mock](http://www.voidspace.org.uk/python/mock/) (part of the standard library in Python 3), but I wanted to hold off adding a new dependency unless you thought it was a good idea.
