### PR TITLE
Travis: speedups, Python 2.6 coverage, badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 env:
   matrix:
-    - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.tar.gz
-    - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.7.x.tar.gz
-    - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.8.x.tar.gz
+    - DJANGO_PACKAGE="Django>=1.6,<1.7"
+    - DJANGO_PACKAGE="Django>=1.7,<1.8"
+    - DJANGO_PACKAGE="Django>=1.8,<1.9"
 install:
   - sudo apt-get install swig
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
+python:
+  - 2.7
 env:
-  matrix:
-    - DJANGO_PACKAGE="Django>=1.6,<1.7"
-    - DJANGO_PACKAGE="Django>=1.7,<1.8"
-    - DJANGO_PACKAGE="Django>=1.8,<1.9"
+  - DJANGO_PACKAGE="Django>=1.6,<1.7"
+  - DJANGO_PACKAGE="Django>=1.7,<1.8"
+  - DJANGO_PACKAGE="Django>=1.8,<1.9"
+matrix:
+  include:
+    - python: 2.6
+      env: DJANGO_PACKAGE="Django>=1.6,<1.7"
 install:
   - sudo apt-get install swig
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,20 @@
 language: python
+
+# Run jobs on container-based infrastructure, can be overridden per job
+sudo: false
+
+# Travis whitelists the installable packages, additions can be requested
+#   https://github.com/travis-ci/apt-package-whitelist
+addons:
+  apt:
+    packages:
+      - swig
+
+# Save pip's downloads/packages/wheels between job runs
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 python:
   - 2.7
 env:
@@ -10,8 +26,7 @@ matrix:
     - python: 2.6
       env: DJANGO_PACKAGE="Django>=1.6,<1.7"
 install:
-  - sudo apt-get install swig
-  - pip install --upgrade pip
+  - pip install --upgrade pip wheel
   - pip install -q $DJANGO_PACKAGE 
   - pip install -e .
   - pip install -r ./testproj/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Django U2F
 ----------
 
+.. image:: https://travis-ci.org/gavinwahl/django-u2f.svg?branch=master
+    :alt: Build Status
+    :target: https://travis-ci.org/gavinwahl/django-u2f
+
 django-u2f provides support for FIDO U2F security tokens in Django. The
 functionality is similar to the `Security Key two-factor authentication that
 Google recently announced


### PR DESCRIPTION
Once packages have been cached then the speedups take each job from 1 minute to 40 seconds, they also start quicker.

The only line I wasn't sure about is `pip freeze`. What's it there for?