### PR TITLE
Constrain django version to avoid staticfiles removal in Django3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'python-u2flib-server>=5.0.0',
         'django-argonauts',
-        'django>=1.11',
+        'django>=1.11,<3.0.0',
         'qrcode',
         'six',
     ],


### PR DESCRIPTION
**If merged this PR will**
Constrain the Django version to Below Django 3.0. `staticfiles` was [deprecated and removed in Django 3+](https://stackoverflow.com/a/59401008/2734863). Without this constraint the most recent version of Django is used leading to the below issue.

Ideally someone will open a PR in the future so that this package can work in Django 3.0+

**Steps to Reproduce issue this PR Addresses:**
Follow the **Demo** setup instructions. When you visit `https://localhost:8000/u2f/login` you will be met with the below KeyError:

```
127.0.0.1 - - [02/Nov/2021 21:24:36] "GET /u2f/login/ HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/defaulttags.py", line 1034, in find_library
    return parser.libraries[name]
KeyError: 'staticfiles'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/contrib/staticfiles/handlers.py", line 76, in __call__
    return self.application(environ, start_response)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/wsgi.py", line 133, in __call__
    response = self.get_response(request)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 130, in get_response
    response = self._middleware_chain(request)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 49, in inner
    response = response_for_exception(request, exc)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 114, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 149, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django_extensions/management/technical_response.py", line 40, in null_technical_500_response
    raise exc_value.with_traceback(tb)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 204, in _get_response
    response = response.render()
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/response.py", line 105, in render
    self.content = self.rendered_content
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/response.py", line 83, in rendered_content
    return template.render(context, self._request)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/backends/django.py", line 61, in render
    return self.template.render(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 170, in render
    return self._render(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/test/utils.py", line 100, in instrumented_test_render
    return self.nodelist.render(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 938, in render
    bit = node.render_annotated(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 905, in render_annotated
    return self.render(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 127, in render
    compiled_parent = self.get_parent(context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 124, in get_parent
    return self.find_template(parent, context)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 103, in find_template
    template, origin = context.template.engine.find_template(
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/engine.py", line 125, in find_template
    template = loader.get_template(name, skip=skip)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/loaders/base.py", line 29, in get_template
    return Template(
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 155, in __init__
    self.nodelist = self.compile_nodelist()
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 193, in compile_nodelist
    return parser.parse()
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 478, in parse
    raise self.error(token, e)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 476, in parse
    compiled_result = compile_func(self, token)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/loader_tags.py", line 278, in do_extends
    nodelist = parser.parse()
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 478, in parse
    raise self.error(token, e)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/base.py", line 476, in parse
    compiled_result = compile_func(self, token)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/defaulttags.py", line 1091, in load
    lib = find_library(parser, name)
  File "/home/cornelis/git/django-u2f/venv/lib/python3.8/site-packages/django/template/defaulttags.py", line 1036, in find_library
    raise TemplateSyntaxError(
django.template.exceptions.TemplateSyntaxError: 'staticfiles' is not a registered tag library. Must be one of:
admin_list
admin_modify
admin_urls
argonauts
cache
debugger_tags
highlighting
i18n
indent_text
l10n
log
static
syntax_color
tz
widont

```