### PR TITLE
Prevent additional migrations when using Django >= 3.2

### DIFF
--- a/django_u2f/apps.py
+++ b/django_u2f/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class U2FConfig(AppConfig):
     name = 'django_u2f'
+    default_auto_field = 'django.db.models.AutoField'
 
     def monkeypatch_login_view(self):
         from .admin import monkeypatch_admin


### PR DESCRIPTION
Prevents django from making additional migration to alter id to BigAutoField